### PR TITLE
[고도화] MySQL -> PostgreSQL

### DIFF
--- a/project-board/build.gradle
+++ b/project-board/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/project-board/src/main/resources/application.yaml
+++ b/project-board/src/main/resources/application.yaml
@@ -9,11 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mariadb://localhost:3306/board
-    username: hyeon8900
+    url: jdbc:postgresql://localhost:5432/board
+    username: jamsiman
     password: shvhsy8571@
-    driver-class-name: org.mariadb.jdbc.Driver
-
   jpa:
     defer-datasource-initialization: true
     hibernate.ddl-auto: create


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL -> PostgreSQL로 전환 성공.